### PR TITLE
Use port 8000 for development and callback function

### DIFF
--- a/WebServer/main.js
+++ b/WebServer/main.js
@@ -6,10 +6,10 @@ app.get('/oauth/redirect', (req, res) => {
     
     let query = req.query;
     console.log(query);
-
     res.sendFile(__dirname + '/public/connected.html');
 })
 
 app.use(express.static(__dirname + '/public'))
-app.listen(80)
-console.log("Webserver Running")
+app.listen(8000, () => {
+    console.log("Webserver Running")
+})


### PR DESCRIPTION
Need root permissions to open server on port 80. Use 8000 for development.